### PR TITLE
Add stream support to `ReaderT` macro

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,10 @@ lazy val macros = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     moduleName := "cats-tagless-macros",
     scalacOptions := scalacOptions.value.filterNot(_.startsWith("-Wunused")).filterNot(_.startsWith("-Ywarn-unused")),
-    libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test
+    libraryDependencies ++= Seq(
+      "co.fs2" %% "fs2-core" % "3.3.0" % Optional,
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test
+    )
   )
 
 lazy val testsJVM = tests.jvm

--- a/macros/src/main/scala/cats/tagless/Derive.scala
+++ b/macros/src/main/scala/cats/tagless/Derive.scala
@@ -19,7 +19,7 @@ package cats.tagless
 import cats.arrow.Profunctor
 import cats.data.ReaderT
 import cats.tagless.aop.{Aspect, Instrument}
-import cats.{Apply, Bifunctor, Contravariant, FlatMap, Functor, Invariant, Semigroupal}
+import cats.{Apply, Bifunctor, Contravariant, FlatMap, Functor, Invariant, Monad, Semigroupal}
 
 object Derive {
 
@@ -33,6 +33,10 @@ object Derive {
     * form of dependency injection.
     */
   def readerT[Alg[_[_]], F[_]]: Alg[ReaderT[F, Alg[F], *]] = macro DeriveMacros.readerT[Alg, F]
+
+  /** As readerT, but also supports methods that return Stream[F, _]
+    */
+  def readerTStream[Alg[_[_]], F[_]: Monad]: Alg[ReaderT[F, Alg[F], *]] = macro DeriveMacros.readerTStream[Alg, F]
 
   def functor[F[_]]: Functor[F] = macro DeriveMacros.functor[F]
   def contravariant[F[_]]: Contravariant[F] = macro DeriveMacros.contravariant[F]

--- a/macros/src/main/scala/cats/tagless/DeriveMacros.scala
+++ b/macros/src/main/scala/cats/tagless/DeriveMacros.scala
@@ -733,13 +733,11 @@ class DeriveMacros(val c: blackbox.Context) {
           case Parameter(_, pt, _) if pt.typeSymbol == f =>
             abort("Not implemented")
         } { case delegate =>
-          val r = q"${reify(fs2.Stream)}.eval[({type L[A] = ${ReaderT.typeSymbol}[$F, $Af, A]})#L, $Rt](${reify(
+          q"${reify(fs2.Stream)}.eval[({type L[A] = ${ReaderT.typeSymbol}[$F, $Af, A]})#L, $Rt](${reify(
               cats.data.Reader
             )}[$Af, $Rt](($af: $Af) => $delegate).lift[$F]).flatMap(_.translate(${reify(
               cats.data.Kleisli
             )}.liftK[$F, $Af]))"
-          println(r)
-          r
         }
       case method =>
         abort(


### PR DESCRIPTION
Not sure if this is worth contributing upstream or too specific, WDYT?

Added `readerTStream` implementation that derives `ReaderT` for instances where some of the methods return `Stream[F, A]`. Separate from `readerT` since it requires a monad constraint that the original implementation doesn't.

Parameter handling not currently implemented.